### PR TITLE
fix conversion to number

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,8 @@
 		jonStr[[0, 2]] = ['N', 'k']
 		console.log(jonStr)
 
+		// does not break casting arrays to number
+		console.log(Number([1]))
 	</script>
 
 </body>

--- a/turboprop.js
+++ b/turboprop.js
@@ -37,6 +37,7 @@ export function initialise(array = [], targetOrTargets = DEFAULT_TARGETS) {
 
 		// retain normal behaviour of array coercion if asked for 'default'
 		if (hint === 'default') return this.toString()
+		if (hint === 'number') return Number(this.toString())
 
 		const
 			keys = this.map(key => (Array.isArray(key) && !isInitialisedArray(key)) ? initialise(key, targets) : key),


### PR DESCRIPTION
I noticed that this breaks when the hint is `number`, based on my understanding and tests*, this fixes it.

* my test:

```js
const compare = (...args) => console.table(
    Object.fromEntries(
        args.map(x => [
            `[${x.join(', ')}]`,
            [
                Number(x),
                Number(x.toString()),
                Object.is(Number(x), Number(x.toString()))
            ]
        ])
    )
)
compare([1], [], [[2]], [3, 4])
```